### PR TITLE
Explicitly specify --no-cone mode for sparse-checkout

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,9 +12,13 @@ runs:
         REPO="https://${GITHUB_ACTOR}:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git"
         BRANCH="${GITHUB_REF/#refs\/heads\//}"
         git clone --filter=blob:none --no-checkout --depth 1 --sparse $REPO .
-        # TODO: support --cone
-        git sparse-checkout init
+
+        # TODO: support the option to use --cone
+        # Currently --no-cone is explicitly specified to allow arbitrary patterns.
+        # See https://git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems
+        git sparse-checkout init --no-cone
         git sparse-checkout set ${{ inputs.pattern }}
+
         # Fetch and checkout the branch being tested
         git fetch --no-tags --prune --progress --depth=1 origin +${GITHUB_SHA}:refs/remotes/origin/${BRANCH}
         git checkout --progress --force -B $BRANCH refs/remotes/origin/$BRANCH


### PR DESCRIPTION
GitHub recently updated Git to v2.37.0. One of the changes is that [`sparse-checkout` uses `--cone` mode by default](https://lore.kernel.org/git/xmqqzgmrv7d1.fsf@gitster.g/T/). Since cone mode only accepts directories (no patterns or exclusions), it was causing some CI tests to fail.

[`--no-cone` is eventually going to be deprecated](https://git-scm.com/docs/git-sparse-checkout/2.37.0#_internalsnon_cone_problems), but without the exclusion pattern it's a little unwieldy to say "give me A/ but not A/C/ and A/D/".